### PR TITLE
Add charset declaration and change the cursor to a pointer for navigation tabs

### DIFF
--- a/PC-Building-Simulator/HTML-Calculator/Current-Version/PC-Building-Simulator-HTML-Calculator.html
+++ b/PC-Building-Simulator/HTML-Calculator/Current-Version/PC-Building-Simulator-HTML-Calculator.html
@@ -1,6 +1,7 @@
 <html>
 
 <head>
+    <meta charset="windows-1252"/>
     <title>PC Building Simulator - HTML Calculator v1.10.0 Build 1 - 3DMark Scores, Builds, Upgrades</title>
     <style>
         body {
@@ -32,6 +33,7 @@
             margin-left: -7px;
             font-size: 18px;
             font-weight: bold;
+            cursor: pointer;
         }
 
         #divOptions {


### PR DESCRIPTION
This is a small change to do two things.

1. There are trademark and dash characters in some of the part names that are from the windows extended character set that don't display properly since browsers assume utf-8 encodings in the absence of an explicit character set declaration. I've added that explicit declaration.

2. As a small enhancement I've added cursor:pointer for the navigation tabs to make it more visually clear that they are clickable.